### PR TITLE
Fix mkdir flag for lualsp_install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -110,7 +110,7 @@ rust_install(){
 
 lualsp_install() {
     echo "Installing lua-lsp..."
-    sudo -p mkdir /opt/lua-lsp
+    sudo mkdir -p /opt/lua-lsp
     sudo chown "$USER:$GROUP" /opt/lua-lsp
     (cd /opt/lua-lsp \
         && curl -L https://github.com/sumneko/lua-language-server/releases/download/2.5.6/lua-language-server-2.5.6-linux-x64.tar.gz | tar xzf - \


### PR DESCRIPTION
`lualsp_install()` would fail due to incorrect placement of `-p` flag for creating `/opt/lua-lsp` directory. Positioning the flag after `mkdir` fixes this.